### PR TITLE
Add support for automatic reminder comments

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -11,6 +11,7 @@ on:
       - closed
 permissions:
   contents: write
+  pull-requests: write
 jobs:
   backlogger:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Have a look at the [demo hosted on GitHub Pages](https://kalikiana.github.io/bac
 
 By default a file *queries.yaml* is expected to contain the queries and limits for your project.
 
+## args
+
+Additional arguments affecting the behavior of the script:
+
+`--reminder-comment-on-issues` can be added here to enable automatic reminder comments. This is **not** enabled by default because it's designed to be used in scheduled runs. Manual execution and previews of changed queries are not expected to have side-effects.
+
 ## folder
 
 The output folder for the generated HTML. By default this is `gh-pages`.
@@ -33,6 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: kalikiana/backlogger@main
           redmine_api_key: ${{ secrets.REDMINE_API_KEY }}
+          args: --reminder-comment-on-issues
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: gh-pages
@@ -52,6 +59,7 @@ on:
       - closed
 permissions:
   contents: write
+  pull-requests: write
 jobs:
   backlogger:
     runs-on: ubuntu-latest

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: The configuration file
     required: false
     default: 'queries.yaml'
+  args:
+    description: Additional arguments to the script
+    required: false
+    default: ''
   folder:
     description: Output folder for HTML files
     required: false
@@ -36,7 +40,7 @@ runs:
     - run: sudo apt-get install -y kramdown
       shell: bash
     - name: Render Markdown from configured backlog queries
-      run: python backlogger/backlogger.py ${{ inputs.config }}
+      run: python backlogger/backlogger.py ${{ inputs.config }} ${{ inputs.args }}
       env:
         REDMINE_API_KEY: ${{ inputs.REDMINE_API_KEY }}
       shell: bash

--- a/queries.yaml
+++ b/queries.yaml
@@ -1,5 +1,7 @@
 api: https://progress.opensuse.org/issues.json
 web: https://progress.opensuse.org/issues
+team: Example
+url: http://example.com
 queries:
   - title: Workable Backlog
     query: query_id=478


### PR DESCRIPTION
The feature needs to be explicitly enabled via a command-line argument. A comment including the priority and a reference to the team website will be added to tickets in the query.

See: https://progress.opensuse.org/issues/113797