### PR TITLE
No reminder comments for exceeded due dates

### DIFF
--- a/backlogger.py
+++ b/backlogger.py
@@ -69,7 +69,7 @@ def list_issues(conf, root):
     try:
         for poo in root['issues']:
             print(data['web'] + '/' + str(poo['id']))
-            if 'update_on' in conf['query'] or 'due_date' in conf['query']:
+            if 'update_on' in conf['query']:
                 issue_reminder(poo)
     except KeyError:
         print("There was an error retrieving the issues " + conf['title'])


### PR DESCRIPTION
Currently there is no explicit checks on wether a comment was added outside of relying on the update filter. Rely on Redmine's built-in handling of due dates instead.

See: https://progress.opensuse.org/issues/113797#note-15